### PR TITLE
feat: add api and query layers

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,6 +54,7 @@ export const metadata: Metadata = {
 };
 
 import { ThemeProvider } from '@/components/layout/theme-provider';
+import { QueryProvider } from '@/lib/query';
 
 export default function RootLayout({
    children,
@@ -67,8 +68,10 @@ export default function RootLayout({
          </head>
          <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background`}>
             <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-               {children}
-               <Toaster />
+               <QueryProvider>
+                  {children}
+                  <Toaster />
+               </QueryProvider>
             </ThemeProvider>
          </body>
       </html>

--- a/hooks/tasks.ts
+++ b/hooks/tasks.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export interface Task {
+   id: number;
+   title: string;
+   description?: string;
+   status: string;
+   projectId?: string;
+}
+
+export function useTasks(params?: { projectId?: string; status?: string; q?: string }) {
+   return useQuery({
+      queryKey: ['tasks', params],
+      queryFn: async () => {
+         const search = new URLSearchParams();
+         if (params?.projectId) search.set('projectId', params.projectId);
+         if (params?.status) search.set('status', params.status);
+         if (params?.q) search.set('q', params.q);
+         const query = search.toString();
+         return api.get<Task[]>(`/tasks${query ? `?${query}` : ''}`);
+      },
+   });
+}
+
+export function useCreateTask() {
+   const queryClient = useQueryClient();
+   return useMutation({
+      mutationFn: (data: Partial<Task>) => api.post<Task>('/tasks', data),
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['tasks'] }),
+   });
+}
+
+export function useUpdateTask() {
+   const queryClient = useQueryClient();
+   return useMutation({
+      mutationFn: ({ id, ...data }: { id: number } & Partial<Task>) =>
+         api.put<Task>(`/tasks/${id}`, data),
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['tasks'] }),
+   });
+}
+
+export function useCompleteTask() {
+   const queryClient = useQueryClient();
+   return useMutation({
+      mutationFn: (id: number) => api.post<Task>(`/tasks/${id}/complete`, {}),
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['tasks'] }),
+   });
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,25 @@
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+   const res = await fetch(`${BASE_URL}${path}`, {
+      ...init,
+      headers: {
+         'Content-Type': 'application/json',
+         ...(init.headers || {}),
+      },
+   });
+   if (!res.ok) {
+      throw new Error(await res.text());
+   }
+   return res.json() as Promise<T>;
+}
+
+export const api = {
+   get: <T>(path: string) => request<T>(path),
+   post: <T>(path: string, body: unknown) =>
+      request<T>(path, { method: 'POST', body: JSON.stringify(body) }),
+   put: <T>(path: string, body: unknown) =>
+      request<T>(path, { method: 'PUT', body: JSON.stringify(body) }),
+};
+
+export type ApiResult<T> = Promise<T>;

--- a/lib/query.tsx
+++ b/lib/query.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useEffect } from 'react';
+
+export const queryClient = new QueryClient();
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+   useEffect(() => {
+      const url = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:3000';
+      const ws = new WebSocket(url);
+      ws.addEventListener('message', (event) => {
+         try {
+            const data = JSON.parse(event.data);
+            if (data.event === 'tasks.updated') {
+               queryClient.invalidateQueries({ queryKey: ['tasks'] });
+            }
+         } catch (e) {
+            console.error(e);
+         }
+      });
+      return () => ws.close();
+   }, []);
+
+   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
       "@radix-ui/react-toggle": "^1.1.2",
       "@radix-ui/react-tooltip": "^1.1.8",
       "@remixicon/react": "^4.6.0",
+      "@tanstack/react-query": "^5.85.5",
       "better-sqlite3": "^9.4.1",
       "class-variance-authority": "^0.7.1",
       "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@remixicon/react':
         specifier: ^4.6.0
         version: 4.6.0(react@19.0.0)
+      '@tanstack/react-query':
+        specifier: ^5.85.5
+        version: 5.85.5(react@19.0.0)
       better-sqlite3:
         specifier: ^9.4.1
         version: 9.6.0
@@ -1934,6 +1937,14 @@ packages:
 
   '@tailwindcss/postcss@4.0.8':
     resolution: {integrity: sha512-SUwlrXjn1ycmUbA0o0n3Y0LqlXqxN5R8HR+ti+OBbRS79wl2seDmiypEs3xJCuQXe07ol81s1AmRMitBmPveJA==}
+
+  '@tanstack/query-core@5.85.5':
+    resolution: {integrity: sha512-KO0WTob4JEApv69iYp1eGvfMSUkgw//IpMnq+//cORBzXf0smyRwPLrUvEe5qtAEGjwZTXrjxg+oJNP/C00t6w==}
+
+  '@tanstack/react-query@5.85.5':
+    resolution: {integrity: sha512-/X4EFNcnPiSs8wM2v+b6DqS5mmGeuJQvxBglmDxl6ZQb5V26ouD2SJYAcC3VjbNwqhY2zjxVD15rDA5nGbMn3A==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
@@ -5530,6 +5541,13 @@ snapshots:
       lightningcss: 1.29.1
       postcss: 8.5.3
       tailwindcss: 4.0.8
+
+  '@tanstack/query-core@5.85.5': {}
+
+  '@tanstack/react-query@5.85.5(react@19.0.0)':
+    dependencies:
+      '@tanstack/query-core': 5.85.5
+      react: 19.0.0
 
   '@types/better-sqlite3@7.6.13':
     dependencies:


### PR DESCRIPTION
## Summary
- add fetch-based API client
- configure react-query with websocket invalidation
- provide task hooks for fetching and mutating tasks

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b27a35eb30832ea64eca48ee57fe9c