### PR TITLE
feat(server): add suggestion endpoint

### DIFF
--- a/server/src/domain/suggest.test.ts
+++ b/server/src/domain/suggest.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { scoreTask, SuggestOptions, Task } from './suggest';
+
+const baseTask: Task = {
+   id: 1,
+   title: 't',
+   description: null,
+   priority: 'MED',
+   status: 'TODO',
+   dueAt: null,
+   createdAt: new Date(),
+   updatedAt: new Date(),
+   effortMinutes: null,
+   person: null,
+   context: null,
+   impact: null,
+   waitingOn: null,
+   why: null,
+   projectId: null,
+   assigneeId: null,
+};
+
+test('overdue tasks score higher for deadline mode', () => {
+   const now = new Date();
+   const past: Task = { ...baseTask, id: 1, dueAt: new Date(now.getTime() - 86400000) };
+   const future: Task = { ...baseTask, id: 2, dueAt: new Date(now.getTime() + 5 * 86400000) };
+   const opts: SuggestOptions = { mode: 'deadline' };
+   const pastScore = scoreTask(past, opts, now).score;
+   const futureScore = scoreTask(future, opts, now).score;
+   assert.ok(pastScore > futureScore);
+});
+
+test('tasks that fit energy score higher', () => {
+   const now = new Date();
+   const small: Task = { ...baseTask, id: 3, effortMinutes: 30 };
+   const big: Task = { ...baseTask, id: 4, effortMinutes: 120 };
+   const opts: SuggestOptions = { mode: 'quickwins', energy: 60 };
+   const smallScore = scoreTask(small, opts, now).score;
+   const bigScore = scoreTask(big, opts, now).score;
+   assert.ok(smallScore > bigScore);
+});
+
+test('waiting tasks get penalized', () => {
+   const now = new Date();
+   const ready: Task = { ...baseTask, id: 5 };
+   const waiting: Task = { ...baseTask, id: 6, waitingOn: 'x' };
+   const opts: SuggestOptions = { mode: 'auto' };
+   const readyScore = scoreTask(ready, opts, now).score;
+   const waitingScore = scoreTask(waiting, opts, now).score;
+   assert.ok(readyScore > waitingScore);
+});

--- a/server/src/domain/suggest.ts
+++ b/server/src/domain/suggest.ts
@@ -1,0 +1,121 @@
+import { tasks } from '../db/schema';
+import { and, eq, ne } from 'drizzle-orm';
+
+export type Task = typeof tasks.$inferSelect;
+
+export type SuggestMode = 'auto' | 'deadline' | 'impact' | 'quickwins';
+
+export interface SuggestOptions {
+   mode: SuggestMode;
+   context?: string;
+   person?: string;
+   energy?: number; // available minutes
+}
+
+interface ScoreResult {
+   score: number;
+   reason: string;
+}
+
+const impactMap: Record<string, number> = { LOW: 1, MED: 2, HIGH: 3 };
+const priorityMap: Record<string, number> = { LOW: 1, MED: 2, HIGH: 3, URGENT: 4 };
+
+function ageInDays(date: Date, now: Date) {
+   return (now.getTime() - date.getTime()) / 86_400_000;
+}
+
+const modeWeights: Record<SuggestMode, Record<string, number>> = {
+   auto: { deadline: 3, impact: 2, priority: 1, aging: 1, person: 2, effort: 3, waiting: 2 },
+   deadline: { deadline: 5, impact: 1, priority: 1, aging: 1, person: 1, effort: 1, waiting: 1 },
+   impact: { deadline: 1, impact: 5, priority: 1, aging: 1, person: 1, effort: 1, waiting: 1 },
+   quickwins: { deadline: 1, impact: 1, priority: 1, aging: 1, person: 1, effort: 5, waiting: 5 },
+};
+
+export function scoreTask(task: Task, opts: SuggestOptions, now: Date = new Date()): ScoreResult {
+   const w = modeWeights[opts.mode];
+   let score = 0;
+   const reasons: string[] = [];
+
+   // Deadline urgency
+   if (task.dueAt) {
+      const days = (task.dueAt.getTime() - now.getTime()) / 86_400_000;
+      const urgency = days <= 0 ? 1 : 1 / (1 + days);
+      score += urgency * w.deadline * 10;
+      reasons.push(`deadline ${days <= 0 ? 'overdue' : `${Math.round(days)}d`}`);
+   }
+
+   // Impact
+   if (task.impact) {
+      const val = impactMap[task.impact] ?? 0;
+      score += val * w.impact * 5;
+      reasons.push(`impact ${task.impact}`);
+   }
+
+   // Priority
+   if (task.priority) {
+      const val = priorityMap[task.priority] ?? 0;
+      score += val * w.priority * 2;
+      reasons.push(`priority ${task.priority}`);
+   }
+
+   // Aging
+   if (task.createdAt) {
+      const age = ageInDays(task.createdAt, now);
+      const val = Math.min(age / 30, 1); // max at 30 days
+      score += val * w.aging * 5;
+      reasons.push(`age ${Math.round(age)}d`);
+   }
+
+   // Person weight
+   if (opts.person && task.person === opts.person) {
+      score += w.person * 5;
+      reasons.push('you');
+   }
+
+   // Effort vs energy
+   if (opts.energy && task.effortMinutes) {
+      const ratio = opts.energy / task.effortMinutes;
+      const val = Math.min(ratio, 1);
+      score += val * w.effort * 10;
+      reasons.push(`effort ${task.effortMinutes}m`);
+   }
+
+   // Waiting resolved
+   if (task.waitingOn) {
+      score -= w.waiting * 5;
+      reasons.push('waiting');
+   } else {
+      score += w.waiting * 5;
+   }
+
+   return { score, reason: reasons.join(', ') };
+}
+
+export async function suggestNext(opts: SuggestOptions) {
+   const { db } = await import('../db/drizzle');
+   const now = new Date();
+   const whereClauses = [ne(tasks.status, 'DONE')];
+   if (opts.context) {
+      whereClauses.push(eq(tasks.context, opts.context));
+   }
+   if (opts.person) {
+      whereClauses.push(eq(tasks.person, opts.person));
+   }
+
+   const rows = await db
+      .select()
+      .from(tasks)
+      .where(and(...whereClauses));
+
+   const suggestions = rows
+      .map((task) => {
+         const { score, reason } = scoreTask(task as Task, opts, now);
+         return { task, score, reason };
+      })
+      .filter((s) => s.score > 0)
+      .sort((a, b) => b.score - a.score);
+
+   return suggestions;
+}
+
+export type Suggestion = Awaited<ReturnType<typeof suggestNext>>[number];

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,6 +3,7 @@ import cors from '@fastify/cors';
 import { env } from './config/env';
 import { setupWebsocket } from './ws';
 import { createTask, updateTask, completeTask } from './services/tasks';
+import { suggestNext } from './domain/suggest';
 
 const app = Fastify({ logger: true });
 
@@ -27,6 +28,25 @@ app.post('/tasks/:id/complete', async (request, reply) => {
    const { id } = request.params as { id: string };
    const task = await completeTask(Number(id));
    reply.send(task);
+});
+
+app.get('/suggest', async (request, reply) => {
+   const {
+      mode = 'auto',
+      limit = '5',
+      context,
+      person,
+      energy,
+   } = request.query as Record<string, string>;
+
+   const suggestions = await suggestNext({
+      mode: mode as any,
+      context,
+      person,
+      energy: energy ? Number(energy) : undefined,
+   });
+
+   reply.send(suggestions.slice(0, Number(limit)));
 });
 
 const start = async () => {


### PR DESCRIPTION
## Summary
- add task scoring utilities and suggestion computation
- expose `/suggest` endpoint
- cover scoring edge cases with tests

## Testing
- `pnpm lint`
- `pnpm tsx --test server/src/domain/suggest.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b27b8d0ef8832eb0396a8d9734f660